### PR TITLE
Bump pipeline from 1.37.5 to 1.37.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,29 +1,20 @@
-### Go template
-# If you prefer the allow list template instead of the deny list, see community template:
-# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+# Copyright 2018-2020 the original author or authors.
 #
-# Binaries for programs and plugins
-*.exe
-*.exe~
-*.dll
-*.so
-*.dylib
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-# Test binary, built with `go test -c`
-*.test
+bin/
+linux/
+dependencies/
+package/
+scratch/
 
-# Output of the go coverage tool, specifically when used with LiteIDE
-*.out
-bin
-
-# Dependency directories (remove the comment below to include it)
-# vendor/
-
-# Go workspace file
-go.work
-
-# ide
-.idea
-.github
-!.github/pipeline-descriptor.yml
-!.github/workflows/pb-update-pipeline.yml

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,30 +1,19 @@
 #!/usr/bin/env bash
-# Copyright (c) The Amphitheatre Authors. All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 set -euo pipefail
 
 GOMOD=$(head -1 go.mod | awk '{print $2}')
-GOOS="linux" go build -ldflags='-s -w' -o bin/main ${GOMOD}/cmd/main
+GOOS="linux" go build -ldflags='-s -w' -o linux/amd64/bin/main "$GOMOD/cmd/main"
+GOOS="linux" GOARCH="arm64" go build -ldflags='-s -w' -o linux/arm64/bin/main "$GOMOD/cmd/main"
 
 if [ "${STRIP:-false}" != "false" ]; then
-  strip bin/main
+  strip linux/amd64/bin/main linux/arm64/bin/main
 fi
 
 if [ "${COMPRESS:-none}" != "none" ]; then
-  $COMPRESS bin/main
+  $COMPRESS linux/amd64/bin/main linux/arm64/bin/main
 fi
 
-ln -fs main bin/build
-ln -fs main bin/detect
+ln -fs main linux/amd64/bin/build
+ln -fs main linux/arm64/bin/build
+ln -fs main linux/amd64/bin/detect
+ln -fs main linux/arm64/bin/detect


### PR DESCRIPTION
Bumps pipeline from `1.37.5` to `1.37.5`.

<details>
<summary>Release Notes</summary>
<h2 dir="auto">🐞 Bug Fixes</h2>
<ul dir="auto">
<li>Missing statik (<a class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="2218756903" data-permission-text="Title is private" data-url="https://github.com/paketo-buildpacks/pipeline-builder/issues/1551" data-hovercard-type="pull_request" data-hovercard-url="/paketo-buildpacks/pipeline-builder/pull/1551/hovercard" href="https://github.com/paketo-buildpacks/pipeline-builder/pull/1551">#1551</a>) <a class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/anthonydahanne/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="https://github.com/anthonydahanne">@anthonydahanne</a></li>
</ul>
</details>